### PR TITLE
Increase fees in accordance with Qtum Core policy

### DIFF
--- a/bitcoin/src/blockdata/script/borrowed.rs
+++ b/bitcoin/src/blockdata/script/borrowed.rs
@@ -318,11 +318,11 @@ impl Script {
     }
 
     /// Returns the minimum value an output with this script should have in order to be
-    /// broadcastable on today's Bitcoin network.
+    /// broadcastable on today's Qtum network.
     pub fn dust_value(&self) -> crate::Amount {
-        // This must never be lower than Bitcoin Core's GetDustThreshold() (as of v0.21) as it may
+        // This must never be lower than Qtum Core's GetDustThreshold() (as of v24.1) as it may
         // otherwise allow users to create transactions which likely can never be broadcast/confirmed.
-        let sats = DUST_RELAY_TX_FEE as u64 / 1000 * // The default dust relay fee is 3000 satoshi/kB (i.e. 3 sat/vByte)
+        let sats = DUST_RELAY_TX_FEE as u64 / 1000 * // The default dust relay fee is 400000 satoshi/kB (i.e. 400 sat/vByte)
         if self.is_op_return() {
             0
         } else if self.is_witness_program() {

--- a/bitcoin/src/policy.rs
+++ b/bitcoin/src/policy.rs
@@ -27,7 +27,8 @@ pub const MIN_STANDARD_TX_NONWITNESS_SIZE: u32 = 82;
 pub const MAX_STANDARD_TX_SIGOPS_COST: u32 = MAX_BLOCK_SIGOPS_COST as u32 / 5;
 
 /// The minimum incremental *feerate* (despite the name), in sats per virtual kilobyte for RBF.
-pub const DEFAULT_INCREMENTAL_RELAY_FEE: u32 = 1_000;
+// Qtum: https://github.com/qtumproject/qtum/blob/time/qtumcore24/src/policy/policy.h#L35
+pub const DEFAULT_INCREMENTAL_RELAY_FEE: u32 = 10_000;
 
 /// The number of bytes equivalent per signature operation. Affects transaction relay through the
 /// virtual size computation.
@@ -35,11 +36,13 @@ pub const DEFAULT_BYTES_PER_SIGOP: u32 = 20;
 
 /// The minimum feerate, in sats per kilo-virtualbyte, for defining dust. An output is considered
 /// dust if spending it under this feerate would cost more in fee.
-pub const DUST_RELAY_TX_FEE: u32 = 3_000;
+// Qtum: https://github.com/qtumproject/qtum/blob/time/qtumcore24/src/policy/policy.h#L55
+pub const DUST_RELAY_TX_FEE: u32 = 400_000;
 
 /// Minimum feerate, in sats per virtual kilobyte, for a transaction to be relayed by most nodes on
 /// the network.
-pub const DEFAULT_MIN_RELAY_TX_FEE: u32 = 1_000;
+// Qtum: https://github.com/qtumproject/qtum/blob/time/qtumcore24/src/policy/policy.h#L57
+pub const DEFAULT_MIN_RELAY_TX_FEE: u32 = 400_000;
 
 /// Default number of hours for an unconfirmed transaction to expire in most of the network nodes'
 /// mempools.


### PR DESCRIPTION
The values of minimum feerates have to be increased to match the values in Qtum Core wallet.
This PR does that.